### PR TITLE
一覧機能の実装

### DIFF
--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -4,7 +4,7 @@ class PrototypesController < ApplicationController
   before_action :move_to_top, only: [:edit, :update]
 
   def index
-    #@prototypes = prototype.all
+    @prototypes = Prototype.includes(:user)
   end
 
   def new

--- a/app/views/prototypes/_prototype.html.erb
+++ b/app/views/prototypes/_prototype.html.erb
@@ -1,0 +1,10 @@
+<div class="card">
+  <%= link_to image_tag(prototype.image, class: :card__img ), root_path%>
+  <div class="card__body">
+    <%= link_to prototype.title, root_path, class: :card__title%>
+    <p class="card__summary">
+      <%= prototype.catch_copy %>
+    </p>
+    <%= link_to "by #{prototype.user.name}", root_path, class: :card__user %>
+  </div>
+</div>

--- a/app/views/prototypes/index.html.erb
+++ b/app/views/prototypes/index.html.erb
@@ -7,7 +7,7 @@
       </div>
     <% end %>
     <div class="card__wrapper">
-      <%# 投稿機能実装後、部分テンプレートでプロトタイプ投稿一覧を表示する %>
+      <%= render partial: 'prototype', collection: @prototypes %>
     </div>
   </div>
 </main>


### PR DESCRIPTION
## What
一覧機能の実装

## Why

### プロトタイプ一覧表示ページは、ログイン状況に関係なく、誰でも見ることができる
https://gyazo.com/bfc0a7352b7684c493d96eea7e538a4f

### 投稿されているプロトタイプが一覧で表示されること
### プロトタイプ毎に、「画像・プロトタイプ名・キャッチコピー・投稿者の名前」の4つの情報が表示されること
### 画像が表示されており、画像がリンク切れなどになっていない
https://gyazo.com/44008911565e5680ea90e723a2c9cae1


